### PR TITLE
Add reverse proxy command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ rustls = "0.23.23"
 rustls-pemfile = "2.2.0"
 hyper-staticfile = "0.10.1"
 scru128 = { version = "3", features = ["serde"] }
+hyper-reverse-proxy = "0.5.1"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use hyper_util::rt::TokioIo;
 use clap::Parser;
 
 use http_nu::{
-    handler::{handle, ResponseStartCommand, StaticCommand},
+    handler::{handle, ResponseStartCommand, ReverseProxyCommand, StaticCommand},
     listener::TlsConfig,
     Engine, Listener, ToSse,
 };
@@ -85,6 +85,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     engine.add_commands(vec![
         Box::new(ResponseStartCommand::new()),
         Box::new(StaticCommand::new()),
+        Box::new(ReverseProxyCommand::new()),
         Box::new(ToSse {}),
     ])?;
     engine.parse_closure(&closure_content)?;


### PR DESCRIPTION
## Summary
- implement `.reverse-proxy` command and config parsing
- support reverse proxy responses in the HTTP handler
- register command in the binary
- document reverse proxy usage and features
- add unit tests for reverse proxy behaviour

## Testing
- `cargo test` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_685f4207b1b0832c95a2c16f3305dc4c