### PR TITLE
fix(ci): populate change log, if empty on release tag push

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -98,8 +98,13 @@ jobs:
           tag="${{ github.ref_name }}"
           changelog="changes/${tag}.md"
           if [ ! -f "$changelog" ]; then
-            previous_tag=$(git describe --tags --abbrev=0 "$tag^")
-            git log --format=%s "${previous_tag}..${tag}" > "$changelog"
+            # Get the previous tag by sorting all tags and finding the one before current
+            previous_tag=$(git tag --list 'v*' --sort=-version:refname | grep -A1 "^${tag}$" | tail -1)
+            if [ -n "$previous_tag" ] && [ "$previous_tag" != "$tag" ]; then
+              git log --format=%s "${previous_tag}..${tag}" > "$changelog"
+            else
+              git log --format=%s "${tag}" > "$changelog"
+            fi
           fi
 
       - name: Publish release

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -93,6 +93,15 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Generate changelog if missing
+        run: |
+          tag="${{ github.ref_name }}"
+          changelog="changes/${tag}.md"
+          if [ ! -f "$changelog" ]; then
+            previous_tag=$(git describe --tags --abbrev=0 "$tag^")
+            git log --format=%s "${previous_tag}..${tag}" > "$changelog"
+          fi
+
       - name: Publish release
         uses: softprops/action-gh-release@v2
         env:


### PR DESCRIPTION
## Summary
- create changelog automatically in the release workflow if missing

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6863e19bb788832ca8434da2d198df41