### PR TITLE
Add failing test for missing Host header

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -1,6 +1,6 @@
 use crate::commands::RESPONSE_TX;
 use crate::request::{request_to_value, Request};
-use crate::response::{value_to_bytes, Response, ResponseTransport};
+use crate::response::{value_to_bytes, Response, ResponseBodyType, ResponseTransport};
 use nu_protocol::{
     engine::{Job, ThreadJob},
     PipelineData, Value,
@@ -116,11 +116,46 @@ pub fn spawn_eval_thread(
     };
 
     std::thread::spawn(move || -> Result<(), std::convert::Infallible> {
-        let mut local_engine = (*engine).clone();
-        local_engine.state.current_job.background_thread_job = Some(job);
+        let mut meta_tx_opt = Some(meta_tx);
+        let mut body_tx_opt = Some(body_tx);
 
-        if let Err(e) = inner(Arc::new(local_engine), request, stream, meta_tx, body_tx) {
-            eprintln!("Error in eval thread: {e}");
+        // Wrap the evaluation in catch_unwind so that panics don't poison the
+        // async runtime and we can still send a response back to the caller.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut local_engine = (*engine).clone();
+            local_engine.state.current_job.background_thread_job = Some(job);
+
+            // Take the senders for the inner call. If the evaluation completes
+            // successfully, these senders will have been consumed. Otherwise we
+            // will use the remaining ones to send an error response.
+            inner(
+                Arc::new(local_engine),
+                request,
+                stream,
+                meta_tx_opt.take().unwrap(),
+                body_tx_opt.take().unwrap(),
+            )
+        }));
+
+        let err_msg: Option<String> = match result {
+            Ok(Ok(())) => None,
+            Ok(Err(e)) => Some(e.to_string()),
+            Err(panic) => Some(format!("panic: {:?}", panic)),
+        };
+
+        if let Some(err) = err_msg {
+            eprintln!("Error in eval thread: {err}");
+            if let (Some(meta_tx), Some(body_tx)) = (meta_tx_opt.take(), body_tx_opt.take()) {
+                let _ = meta_tx.send(Response {
+                    status: 500,
+                    headers: std::collections::HashMap::new(),
+                    body_type: ResponseBodyType::Normal,
+                });
+                let _ = body_tx.send((
+                    Some("text/plain; charset=utf-8".to_string()),
+                    ResponseTransport::Full(format!("Script error: {err}").into_bytes()),
+                ));
+            }
         }
 
         // Clean up job when done

--- a/tests/server_missing_host.rs
+++ b/tests/server_missing_host.rs
@@ -1,0 +1,31 @@
+use tokio::time::Duration;
+
+mod common;
+use common::TestServer;
+
+#[tokio::test]
+async fn test_server_missing_host_header() {
+    let server = TestServer::new(
+        "127.0.0.1:0",
+        "{|req| let host = $req.headers.host; $\"Host: ($host)\" }",
+        false,
+    )
+    .await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let addr = server.address.clone();
+    let mut parts = addr.split(':');
+    let host = parts.next().unwrap();
+    let port = parts.next().unwrap();
+    let output = tokio::process::Command::new("sh")
+        .arg("-c")
+        .arg(format!(
+            "printf 'GET / HTTP/1.0\\r\\n\\r\\n' | nc {} {}",
+            host, port
+        ))
+        .output()
+        .await
+        .expect("run nc");
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(text.contains("500"), "expected 500 status, got: {text}");
+}


### PR DESCRIPTION
## Summary
- add regression test for missing `Host` header that shows request hangs
- catch panics in worker threads and send 500 error response

## Testing
- `cargo test test_server_missing_host_header -- --nocapture`
- `cargo test -- --test-threads=1`


------
https://chatgpt.com/codex/tasks/task_e_686ebafb30e4832c8560df89c1661d94