### PR TITLE
feat: processor engines get http-nu's context-free commands (.mj etc.)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,9 +1166,8 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cross-stream"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8138385fb398870cda06244639caa3bf928a1452b8ee5a37c46f3359df87f63"
+version = "0.13.4-dev"
+source = "git+https://github.com/cablehead/xs?branch=feat%2Fengine-base#5bc1bcd0d1d0bcc1cc46233246afa80b8ea2cd12"
 dependencies = [
  "base64 0.22.1",
  "bon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,8 +1166,9 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "cross-stream"
-version = "0.13.4-dev"
-source = "git+https://github.com/cablehead/xs?branch=feat%2Fengine-base#5bc1bcd0d1d0bcc1cc46233246afa80b8ea2cd12"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0208127642befc45f81b13d05dfc70fc675579330151416b6d0898a466c51d"
 dependencies = [
  "base64 0.22.1",
  "bon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,11 @@ syntect-assets = "0.23.6"
 pulldown-cmark = "0.12.2"
 notify = "8"
 
+# TEMPORARY: track the xs feat/engine-base branch for `Store::with_base_engine`
+# (xs PR #144). Return to a published version once that lands and is released.
 [dependencies.cross-stream]
-version = "0.13.3"
+git = "https://github.com/cablehead/xs"
+branch = "feat/engine-base"
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,11 +71,8 @@ syntect-assets = "0.23.6"
 pulldown-cmark = "0.12.2"
 notify = "8"
 
-# TEMPORARY: track the xs feat/engine-base branch for `Store::with_base_engine`
-# (xs PR #144). Return to a published version once that lands and is released.
 [dependencies.cross-stream]
-git = "https://github.com/cablehead/xs"
-branch = "feat/engine-base"
+version = "0.13.4"
 optional = true
 
 [features]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -387,6 +387,22 @@ impl Engine {
             Box::new(MjCompileCommand::with_store(store.clone())),
         ])
     }
+
+    /// Add http-nu's `.mj` (store-backed), `.md`, and highlight commands to this
+    /// engine, to use as an xs processor base via `Store::with_base_engine` so
+    /// actors, services, and actions can use them. See xs ADR 0007.
+    #[cfg(feature = "cross-stream")]
+    pub fn add_processor_commands(&mut self, store: &xs::store::Store) -> Result<(), Error> {
+        self.add_commands(vec![
+            Box::new(MjCommand::with_store(store.clone())),
+            Box::new(MjCompileCommand::with_store(store.clone())),
+            Box::new(MjRenderCommand::new()),
+            Box::new(MdCommand::new()),
+            Box::new(HighlightCommand::new()),
+            Box::new(HighlightThemeCommand::new()),
+            Box::new(HighlightLangCommand::new()),
+        ])
+    }
 }
 
 /// Creates an engine from a script by cloning a base engine and parsing the closure.

--- a/src/store.rs
+++ b/src/store.rs
@@ -37,6 +37,17 @@ impl Store {
     ) -> Result<Self, xs::store::StoreError> {
         let inner = xs::store::Store::new(path.clone())?;
 
+        // Hand the processors a base engine with http-nu's `.mj`, `.md`, and
+        // highlight commands so actors, services, and actions can use them, not
+        // just HTTP handlers. prepared_base clones this base per spawn. See xs
+        // ADR 0007. Set before any clone so all share it.
+        let inner = {
+            let mut base = crate::Engine::new().expect("Failed to build processor base engine");
+            base.add_processor_commands(&inner)
+                .expect("Failed to register processor base commands");
+            inner.with_base_engine(base.state)
+        };
+
         // API server
         let store_for_api = inner.clone();
         tokio::spawn(async move {

--- a/src/test_engine.rs
+++ b/src/test_engine.rs
@@ -8,6 +8,33 @@ fn eval_engine() -> Engine {
     engine
 }
 
+#[cfg(feature = "cross-stream")]
+#[test]
+fn test_processor_base_command_surface() {
+    use nu_protocol::engine::StateWorkingSet;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let store = xs::store::Store::new(tmp.path().to_path_buf()).unwrap();
+    let mut engine = Engine::new().unwrap();
+    engine.add_processor_commands(&store).unwrap();
+
+    // The context-free commands a processor needs are present...
+    let ws = StateWorkingSet::new(&engine.state);
+    assert!(
+        ws.find_decl(b".mj").is_some(),
+        ".mj must be on the processor base"
+    );
+    assert!(
+        ws.find_decl(b".md").is_some(),
+        ".md must be on the processor base"
+    );
+    // ...and request-scoped commands are not.
+    assert!(
+        ws.find_decl(b".static").is_none(),
+        ".static is request-scoped and must not be on the processor base"
+    );
+}
+
 #[test]
 fn test_engine_eval() {
     let mut engine = Engine::new().unwrap();

--- a/src/test_engine.rs
+++ b/src/test_engine.rs
@@ -18,7 +18,7 @@ fn test_processor_base_command_surface() {
     let mut engine = Engine::new().unwrap();
     engine.add_processor_commands(&store).unwrap();
 
-    // The context-free commands a processor needs are present...
+    // .mj and .md are present...
     let ws = StateWorkingSet::new(&engine.state);
     assert!(
         ws.find_decl(b".mj").is_some(),
@@ -28,10 +28,10 @@ fn test_processor_base_command_surface() {
         ws.find_decl(b".md").is_some(),
         ".md must be on the processor base"
     );
-    // ...and request-scoped commands are not.
+    // ...and .static, an HTTP-handler command, is not.
     assert!(
         ws.find_decl(b".static").is_none(),
-        ".static is request-scoped and must not be on the processor base"
+        ".static must not be on the processor base"
     );
 }
 


### PR DESCRIPTION
## What

Hand the xs processors (actor, service, action) a base engine with http-nu's `.mj`, `.md`, and highlight commands, so they work in a service or actor, not just an HTTP handler.

- `Engine::add_processor_commands(&store)`: store-backed `.mj`/`.mj compile`, `.mj render`, `.md`, `.highlight*`.
- `Store::init` sets this base before the processors spawn; `prepared_base` clones it per spawn.

## Why

`.mj` was registered only on the HTTP engine, so using it in a service failed. Model: xs ADR 0007.

## Notes

- Depends on xs #144 (`with_base_engine`). `cross-stream` temporarily tracks the xs `feat/engine-base` branch; revert to a release once #144 lands.
- No `Engine::new` split: main's is already clean (the server job lives on `www-next-gen`; the split applies there if that is the target).
- Test: `test_processor_base_command_surface`. Lib suite green (85). `test_eval_with_plugin` fails only for a missing `nu_plugin_test` binary (environmental).
