### PR TITLE
feat: add AF_VSOCK listener

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,6 +2774,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-stream",
  "tokio-util",
+ "tokio-vsock",
  "tower",
  "tower-http",
  "typetag",
@@ -3920,6 +3921,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miette"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4316,6 +4326,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -7561,6 +7572,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b319ef9394889dab2e1b4f0085b45ba11d0c79dc9d1a9d1afc057d009d0f1c7"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "tokio-websockets"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8262,6 +8286,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsock"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba782755fc073877e567c2253c0be48e4aa9a254c232d36d3985dfae0bd5205"
+dependencies = [
+ "libc",
+ "nix 0.31.2",
+]
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,10 +76,14 @@ version = "0.13.3"
 optional = true
 
 [features]
-default = ["cross-stream"]
+default = ["cross-stream", "vsock"]
+vsock = ["dep:tokio-vsock"]
 
 [target.'cfg(windows)'.dependencies]
 win_uds = "=0.2.2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tokio-vsock = { version = "0.7.2", optional = true }
 
 [build-dependencies]
 syntect = "5.3.0"

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -158,6 +158,8 @@ pub enum Listener {
     Unix(UnixListener),
     #[cfg(windows)]
     Unix(WinUnixListener),
+    #[cfg(all(target_os = "linux", feature = "vsock"))]
+    Vsock(tokio_vsock::VsockListener),
 }
 
 impl Listener {
@@ -199,10 +201,39 @@ impl Listener {
                 let (stream, _) = listener.accept().await?;
                 Ok((Box::new(stream), None))
             }
+            #[cfg(all(target_os = "linux", feature = "vsock"))]
+            Listener::Vsock(listener) => {
+                // A vsock peer has no IP, just like a Unix domain socket peer,
+                // so report the address as None (see resolve_trusted_ip).
+                let (stream, _peer) = listener.accept().await?;
+                Ok((Box::new(stream), None))
+            }
         }
     }
 
     pub async fn bind(addr: &str, tls_config: Option<TlsConfig>) -> io::Result<Self> {
+        // vsock://<port> or vsock://<cid>:<port> selects an AF_VSOCK listener.
+        if let Some(rest) = addr.strip_prefix("vsock://") {
+            #[cfg(all(target_os = "linux", feature = "vsock"))]
+            {
+                if tls_config.is_some() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        "TLS is not supported with vsock sockets",
+                    ));
+                }
+                return Self::bind_vsock(rest);
+            }
+            #[cfg(not(all(target_os = "linux", feature = "vsock")))]
+            {
+                let _ = rest;
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "vsock support is not compiled in (Linux only, requires the \"vsock\" feature)",
+                ));
+            }
+        }
+
         // Check if address looks like a Unix socket path
         fn is_unix_path(addr: &str) -> bool {
             addr.starts_with('/') || addr.starts_with('.')
@@ -267,6 +298,27 @@ impl Listener {
             }
         }
     }
+
+    #[cfg(all(target_os = "linux", feature = "vsock"))]
+    fn bind_vsock(rest: &str) -> io::Result<Self> {
+        use tokio_vsock::{VsockAddr, VsockListener, VMADDR_CID_ANY};
+
+        // Accept both "<port>" and "<cid>:<port>". Always bind to CID_ANY so the
+        // listener works regardless of the guest's assigned CID; any CID given
+        // on the listen side is accepted but ignored.
+        let port_str = match rest.rsplit_once(':') {
+            Some((_cid, port)) => port,
+            None => rest,
+        };
+        let port: u32 = port_str.parse().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid vsock port: {rest:?} (expected vsock://<port> or vsock://<cid>:<port>)"),
+            )
+        })?;
+        let listener = VsockListener::bind(VsockAddr::new(VMADDR_CID_ANY, port))?;
+        Ok(Listener::Vsock(listener))
+    }
 }
 
 impl Clone for Listener {
@@ -286,6 +338,10 @@ impl Clone for Listener {
             #[cfg(windows)]
             Listener::Unix(_) => {
                 panic!("Cannot clone a Unix listener")
+            }
+            #[cfg(all(target_os = "linux", feature = "vsock"))]
+            Listener::Vsock(_) => {
+                panic!("Cannot clone a vsock listener")
             }
         }
     }
@@ -322,6 +378,11 @@ impl std::fmt::Display for Listener {
                 let path = listener.local_addr().unwrap();
                 write!(f, "{}", path.display())
             }
+            #[cfg(all(target_os = "linux", feature = "vsock"))]
+            Listener::Vsock(listener) => {
+                let addr = listener.local_addr().unwrap();
+                write!(f, "vsock://:{}", addr.port())
+            }
         }
     }
 }
@@ -354,6 +415,11 @@ mod tests {
                 let path = listener.local_addr().unwrap();
                 path.to_string_lossy().to_string()
             }
+            #[cfg(all(target_os = "linux", feature = "vsock"))]
+            Listener::Vsock(listener) => {
+                let addr = listener.local_addr().unwrap();
+                format!("vsock://:{}", addr.port())
+            }
         };
 
         let client_task: tokio::task::JoinHandle<
@@ -368,6 +434,15 @@ mod tests {
             #[cfg(windows)]
             if listener_addr.starts_with('/') || listener_addr.chars().nth(1) == Some(':') {
                 let stream = WinUnixStream::connect(&listener_addr).await?;
+                return Ok(Box::new(stream) as AsyncReadWriteBox);
+            }
+            #[cfg(all(target_os = "linux", feature = "vsock"))]
+            if let Some(port) = listener_addr.strip_prefix("vsock://:") {
+                use tokio_vsock::{VsockAddr, VsockStream, VMADDR_CID_LOCAL};
+                let port: u32 = port.parse().unwrap();
+                // Connect over the host-local CID (1) so the round-trip loops
+                // back on this machine without a hypervisor.
+                let stream = VsockStream::connect(VsockAddr::new(VMADDR_CID_LOCAL, port)).await?;
                 return Ok(Box::new(stream) as AsyncReadWriteBox);
             }
             let stream = TcpStream::connect(&listener_addr).await?;
@@ -397,5 +472,20 @@ mod tests {
         let path = temp_dir.path().join("test.sock");
         let path = path.to_str().unwrap();
         exercise_listener(path).await;
+    }
+
+    #[cfg(all(target_os = "linux", feature = "vsock"))]
+    #[tokio::test]
+    async fn test_bind_vsock() {
+        // Skip when the host has no vsock support (no /dev/vsock or no
+        // vsock_loopback module) so CI without a hypervisor still passes.
+        match Listener::bind("vsock://0", None).await {
+            Ok(_probe) => {}
+            Err(e) => {
+                eprintln!("skipping test_bind_vsock: vsock unavailable: {e}");
+                return;
+            }
+        }
+        exercise_listener("vsock://0").await;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,8 @@ struct Args {
     #[command(subcommand)]
     command: Option<Command>,
 
-    /// Address to listen on [HOST]:PORT or <PATH> for Unix domain socket
+    /// Address to listen on: [HOST]:PORT, <PATH> for a Unix domain socket, or
+    /// vsock://<port> (vsock://<cid>:<port>) for an AF_VSOCK socket (Linux only)
     #[clap(value_parser)]
     addr: Option<String>,
 
@@ -368,8 +369,9 @@ async fn serve(
     let startup_ms = start_time.elapsed().as_millis();
     let addr_display = {
         let raw = format!("{listener}");
-        // Format TCP addresses as clickable URLs, leave Unix sockets as-is
-        if raw.starts_with('/') {
+        // Format TCP addresses as clickable URLs, leave Unix sockets and the
+        // already-prefixed vsock:// form as-is
+        if raw.starts_with('/') || raw.starts_with("vsock://") {
             raw
         } else {
             // Strip " (TLS)" suffix from Listener's Display


### PR DESCRIPTION
Adds a third transport alongside TCP and Unix domain sockets, so a Cloud Hypervisor / libkrun guest can expose http-nu over AF_VSOCK and the host can bridge it to a unix socket.

## Usage
- `http-nu vsock://80 serve.nu` (also accepts `vsock://<cid>:<port>`; always binds `VMADDR_CID_ANY`)

## Details
- Linux-only, behind the `vsock` cargo feature (in `default`); `tokio-vsock` is target-gated so macOS/Windows still build with the feature inert.
- `accept` returns no peer address, like the UDS path: `remote_ip`/`remote_port` stay absent and `--trust-proxy` keeps resolving `X-Forwarded-For` without panicking.
- Startup banner prints `vsock://:<port>`.
- `remote_vsock: {cid, port}` metadata deferred for now.

## Verification
- Builds with and without the `vsock` feature (code fully gated).
- `test_bind_vsock` round-trips over the host-local CID (1), no hypervisor needed.
- `cargo clippy --all-features -D warnings` clean.